### PR TITLE
add CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+book.rust-embedded.org


### PR DESCRIPTION
https://book.rust-embedded.org/ and https://rust-embedded.github.io/book/ are
not displaying the same contents. I believe that's because this file was
missing.

r? @rust-embedded/resources (anyone)
cc @nastevens