### PR TITLE
Insert /book/ into link URL

### DIFF
--- a/src/intro/hardware.md
+++ b/src/intro/hardware.md
@@ -5,7 +5,7 @@ Let's get familiar with the hardware we'll be working with.
 ## STM32F3DISCOVERY (the "F3")
 
 <p align="center">
-<img title="F3" src="/assets/f3.jpg">
+<img title="F3" src="/book/assets/f3.jpg">
 </p>
 
 We'll refer to this board as "F3" throughout this book.


### PR DESCRIPTION
Hopefully this will fix the broken URL for good. However I'm wondering whether we shouldn't make it absolute instead so it would also render correctly in the preview on GitHub...

r? @rust-embedded/resources