### PR TITLE
Attempt to fix mdbook v0.2.2 issue by using v0.2.1

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,6 +6,8 @@ main() {
                     | grep -E '^v[0.1.0-9.]+$' \
                     | sort --version-sort \
                     | tail -n1)
+    # Temporarily use older version until packages are available for 0.2.2 (or newer)
+    local tag="v0.2.1"
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- --git rust-lang-nursery/mdbook --tag $tag
 


### PR DESCRIPTION
v0.2.2 was just released but does not include the relevant packages yet so install.sh fails