### PR TITLE
Update doc URLs to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [the issue tracker] for more details. This is a very early work in progress.
 
 ## Online Copies of this Book
 
-This book is being temporarily hosted in https://rust-embedded.github.io/book/
+This book is located at https://docs.rust-embedded.org/book/
 
 ## License
 

--- a/src/intro/introduction.md
+++ b/src/intro/introduction.md
@@ -57,9 +57,9 @@ If you are unfamiliar with anything mentioned above or if you want more informat
 |--------------|----------|-------------|
 | Rust         | [Rust Book 2018 Edition](https://doc.rust-lang.org/book/2018-edition/index.html) | If you are not yet comfortable with Rust, we highly suggest reading the this book. |
 | Rust         | [Rust Book Second Edition](https://doc.rust-lang.org/book/second-edition) | - |
-| Rust, Embedded | [Embedded Rust Bookshelf](https://rust-embedded.github.io/bookshelf/) | Here you can find several other resources provided by Rust's Embedded Working Group. |
-| Rust, Embedded | [Embedonomicon](https://rust-embedded.github.io/embedonomicon/) | The nitty gritty details when doing embedded programming in Rust. |
-| Rust, Embedded | [embedded FAQ](https://rust-embedded.github.io/bookshelf/faq.html) | Frequently asked questions about Rust in an embedded context. |
+| Rust, Embedded | [Embedded Rust Bookshelf](https://docs.rust-embedded.org) | Here you can find several other resources provided by Rust's Embedded Working Group. |
+| Rust, Embedded | [Embedonomicon](https://docs.rust-embedded.org/embedonomicon/) | The nitty gritty details when doing embedded programming in Rust. |
+| Rust, Embedded | [embedded FAQ](https://docs.rust-embedded.org/faq.html) | Frequently asked questions about Rust in an embedded context. |
 | Interrupts | [Interrupt](https://en.wikipedia.org/wiki/Interrupt) | - |
 | Memory-mapped IO/Peripherals | [Memory-mapped I/O](https://en.wikipedia.org/wiki/Memory-mapped_I/O) | - |
 | SPI, UART, RS232, USB, I2C, TTL | [Stack Exchange about SPI, UART, and other interfaces](https://electronics.stackexchange.com/questions/37814/usart-uart-rs232-usb-spi-i2c-ttl-etc-what-are-all-of-these-and-how-do-th) | - |


### PR DESCRIPTION
Documentation was recently moved to docs.rust-embedded.org and some of
the old links (to bookshelf content) now result in 404 errors.