### PR TITLE
Make transmitter example plural

### DIFF
--- a/src/portability/index.md
+++ b/src/portability/index.md
@@ -53,7 +53,7 @@ Such a **HAL implementation** can come in various flavours:
 
 ### Driver
 
-A driver implements a set of custom functionality for an internal or external component, connected to a peripheral implementing the embedded-hal traits. Typical examples for such drivers include various sensors (temperature, magnetometer, accelerometer, light), display devices (LED arrays, LCD displays) and actors (motors, transmitter).
+A driver implements a set of custom functionality for an internal or external component, connected to a peripheral implementing the embedded-hal traits. Typical examples for such drivers include various sensors (temperature, magnetometer, accelerometer, light), display devices (LED arrays, LCD displays) and actors (motors, transmitters).
 
 A driver has to be initialised with an instance of type that implements a certain `trait` of the embedded-hal which is ensured via trait bound and provides its own type instance with a custom set of methods allowing to interact with the driven device.
 


### PR DESCRIPTION
I switched to using 'transmitter' as an example in my a1c7244 commit
last night when the rest of the examples were plural. This commit adds
the 's' to make it consistent with the other examples.