### PR TITLE
install:linux: Recommend using apt instead of apt-get

### DIFF
--- a/src/intro/install/linux.md
+++ b/src/intro/install/linux.md
@@ -20,7 +20,7 @@ Here are the installation commands for a few Linux distributions.
 <!-- QEMU 2.11.1 -->
 
 ``` console
-$ sudo apt-get install \
+$ sudo apt install \
   gdb-multiarch \
   openocd \
   qemu-system-arm
@@ -37,7 +37,7 @@ $ sudo apt-get install \
 <!-- QEMU 2.0.0 (?) -->
 
 ``` console
-$ sudo apt-get install \
+$ sudo apt install \
   gdb-arm-none-eabi \
   openocd \
   qemu-system-arm


### PR DESCRIPTION
The 'apt' binary has appeared in apt 1.0 back in 2014 and has been
ever since the recommended tool to install packages on Debian based
systems.  It makes little sense to recommend using 'apt-get' instead
of 'apt' when even the current Debian oldstable - jessie - has apt
\>=1.0.9.8 and the Ubuntu 14.04 LTS - trusty - has apt
\>=1.0.1ubuntu1.

Signed-off-by: Eddy Petrișor <eddy.petrisor@gmail.com>