### PR TITLE
static-guarantees: fix typos

### DIFF
--- a/src/static-guarantees/design-contracts.md
+++ b/src/static-guarantees/design-contracts.md
@@ -227,7 +227,7 @@ let input_pin = pin.into_enabled_input();
 let pin_state = input_pin.bit_is_set();
 
 // Can't do this, input pins don't have this interface!
-// pin_state.set_bit(true);
+// input_pin.set_bit(true);
 
 /*
  * Example 2: High-Z input to Pulled Low input

--- a/src/static-guarantees/index.md
+++ b/src/static-guarantees/index.md
@@ -9,7 +9,7 @@ at compile time; reducing the need for runtime checks in some cases.
 
 When applied to embedded programs these *static checks* can be used, for
 example, to enforce that configuration of I/O interfaces is done properly. For
-instance, one can design an API where is only possible to initialize a serial
+instance, one can design an API where it is only possible to initialize a serial
 interface by first configuring the pins that will be used by the interface.
 
 One can also statically check that operations, like setting a pin low, can only


### PR DESCRIPTION
As is says on the tin :)