### PR TITLE
Update the references of UserHardFault, which was renamed to HardFault

### DIFF
--- a/src/start/hardware.md
+++ b/src/start/hardware.md
@@ -293,7 +293,7 @@ set print asm-demangle on
 
 # detect unhandled exceptions, hard faults and panics
 break DefaultHandler
-break UserHardFault
+break HardFault
 break rust_begin_unwind
 
 monitor arm semihosting enable

--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -284,8 +284,8 @@ Reset:
      430:       bl      #0x1c
      434:       b       #-0x4 <Reset+0x34>
 
-UserHardFault_:
-     436:       b       #-0x4 <UserHardFault_>
+HardFault_:
+     436:       b       #-0x4 <HardFault_>
 
 UsageFault:
      438:       b       #-0x4 <UsageFault>


### PR DESCRIPTION
This updates the book to match the [renamed symbol](https://github.com/rust-embedded/cortex-m-rt/pull/144) and my [associated PR](https://github.com/rust-embedded/cortex-m-quickstart/pull/64) updating the quickstart repository.