### PR TITLE
Fix for links not pointing to correct documentation

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -8,7 +8,7 @@ subroutines executed in response to the signal that triggered the event.
 The `cortex-m-rt` crate provides an [`exception`] attribute to declare exception
 handlers.
 
-[`exception`]: https://rust-embedded.github.io/cortex-m-rt/0.6.1/cortex_m_rt_macros/fn.exception.html
+[`exception`]: https://docs.rs/cortex-m-rt-macros/latest/cortex_m_rt_macros/attr.exception.html
 
 ``` rust,ignore
 // Exception handler for the SysTick (System Timer) exception

--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -129,7 +129,7 @@ to mark the entry point of the program. As we are not using the standard `main`
 interface we need another way to indicate the entry point of the program and
 that'd be `#[entry]`.
 
-[`#[entry]`]: https://rust-embedded.github.io/cortex-m-rt/0.6.1/cortex_m_rt_macros/fn.entry.html
+[`#[entry]`]: https://docs.rs/cortex-m-rt-macros/latest/cortex_m_rt_macros/attr.entry.html
 [`cortex-m-rt`]: https://crates.io/crates/cortex-m-rt
 
 `fn main() -> !`. Our program will be the *only* process running on the target


### PR DESCRIPTION
As #107 showed, there are some links pointing to the rendered docs, this pull attempts to fix that.