### PR TITLE
Fix typos in c-tips

### DIFF
--- a/src/c-tips/index.md
+++ b/src/c-tips/index.md
@@ -6,7 +6,7 @@ highlight how things you might already be used to in C are different in Rust.
 
 ## Preprocessor
 
-In embedded C it is very common to use the preprocessor for a varity of
+In embedded C it is very common to use the preprocessor for a variety of
 purposes, such as:
 
 * Compile-time selection of code blocks with `#ifdef`

--- a/src/c-tips/index.md
+++ b/src/c-tips/index.md
@@ -62,7 +62,7 @@ full details of the conditional compilation support, refer to the
 [conditional compilation]: https://doc.rust-lang.org/reference/conditional-compilation.html
 
 The conditional compilation will only apply to the next statement or block. If
-a block can not be used in the current scope then then `cfg` attribute will
+a block can not be used in the current scope then `cfg` attribute will
 need to be used multiple times.  It's worth noting that most of the time it is
 better to simply include all the code and allow the compiler to remove dead
 code when optimising: it's simpler for you and your users, and in general the

--- a/src/c-tips/index.md
+++ b/src/c-tips/index.md
@@ -52,7 +52,7 @@ pub mod iir;
 ```
 
 You can similarly include code blocks only if a feature is _not_ enabled, or if
-any combination or features is or is not enabled.
+any combination of features are or are not enabled.
 
 Additionally, Rust provides a number of automatically-set conditions you can
 use, such as `target_arch` to select different code based on architecture. For

--- a/src/c-tips/index.md
+++ b/src/c-tips/index.md
@@ -62,7 +62,7 @@ full details of the conditional compilation support, refer to the
 [conditional compilation]: https://doc.rust-lang.org/reference/conditional-compilation.html
 
 The conditional compilation will only apply to the next statement or block. If
-a block can not be used in the current scope then `cfg` attribute will
+a block can not be used in the current scope then the `cfg` attribute will
 need to be used multiple times.  It's worth noting that most of the time it is
 better to simply include all the code and allow the compiler to remove dead
 code when optimising: it's simpler for you and your users, and in general the


### PR DESCRIPTION
Just some little typo fixes in "Tips for embedded C developers"