### PR TITLE
Update install.md

### DIFF
--- a/src/intro/install.md
+++ b/src/intro/install.md
@@ -16,10 +16,27 @@ rustc 1.31.1 (b6c32da9b 2018-12-18)
 
 For bandwidth and disk usage concerns the default installation only supports
 native compilation. To add cross compilation support for the ARM Cortex-M
-architecture install the following compilation targets.
+architecture choose one of the following compilation targets. Use the last one
+for the STM32F3DISCOVERY board and follow along with the book.
 
+Cortex M0 M0+
 ``` console
-$ rustup target add thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi thumbv7em-none-eabihf
+$ rustup target add thumbv6m-none-eabi
+```
+
+Cortex M3
+``` console
+$ rustup target add thumbv7m-none-eabi
+```
+
+Cortex M4 M7 without FPU
+``` console
+$ rustup target add thumbv7em-none-eabi
+```
+
+Cortex M4 M7 with FPU <-- STM32F3DISCOVERY
+``` console
+$ rustup target add thumbv7em-none-eabihf
 ```
 
 ### `cargo-binutils`


### PR DESCRIPTION
`For bandwidth and disk usage concerns the default installation only supports native compilation.`
I like what the default installation is doing, not downloading toolchains i don't need. Let's do the same for the book. At the same time, because the reader is just getting into embedded for rust, it's cool to see which toolchains for which CPU cores are already available. This gives a good feeling of control (which toolchain i can choose) and possibilities (many to choose from)