### PR TITLE
Update exceptions.md

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -251,6 +251,7 @@ ResetTrampoline:
  800094c:       b       #-0x4 <ResetTrampoline+0xa>
 ```
 
-You'll see that a load operation (`ldr r0, [r0]` ) caused the exception and that
-the value of the register `r0` was `0x3fff_fffe` at that time. This value
-matches the `r0` field of `ExceptionFrame`.
+You can lookup the value of the program counter `0x0800094a` in the dissassembly.
+You'll see that a load operation (`ldr r0, [r0]` ) caused the exception.
+The `r0` field of `ExceptionFrame` will tell you the value of register `r0`
+was `0x3fff_fffe` at that time.


### PR DESCRIPTION
> You'll see that a load operation (ldr r0, [r0] ) caused the exception and that the value of the register r0 was 0x3fff_fffe at that time.

You can not see the value of the register from the disassembly. Therefor:

> This value matches the r0 field of ExceptionFrame.

`This` points to nothing. Nothing "matches". With the information given in the book the value can _only_ be seen in the ExceptionFrame.