### PR TITLE
install-macos: remove Homebrew tap command

### DIFF
--- a/src/intro/install/macos.md
+++ b/src/intro/install/macos.md
@@ -6,7 +6,6 @@ All the tools can be install using [Homebrew]:
 
 ``` console
 $ # GDB
-$ brew tap armmbed/formulae
 $ brew install armmbed/formulae/arm-none-eabi-gcc
 
 $ # OpenOCD


### PR DESCRIPTION
You don’t need to

```bash
brew tap armmbed/formulae
brew install armmbed/formulae/arm-none-eabi-gcc
```

You either

```bash
brew tap armmbed/formulae
brew install arm-none-eabi-gcc
```

Or you

```bash
brew install armmbed/formulae/arm-none-eabi-gcc
```

Which taps and installs in a single command.