### PR TITLE
Add openocd to list of installable packages

### DIFF
--- a/src/intro/install/linux.md
+++ b/src/intro/install/linux.md
@@ -68,9 +68,9 @@ $ sudo dnf install \
 ``` console
 $ sudo pacman -S \
   arm-none-eabi-gdb \
-  qemu-arch-extra
+  qemu-arch-extra \
+  openocd
 
-$ # install openocd from the AUR -- https://aur.archlinux.org/packages/openocd/
 ```
 
 ## udev rules


### PR DESCRIPTION
The openocd package is now in the community repository of Archlinux.

https://www.archlinux.org/packages/community/x86_64/openocd/