### PR TITLE
Syst small fix

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -82,6 +82,7 @@ fn main() -> ! {
     syst.set_clock_source(SystClkSource::Core);
     // this is configured for the LM3S6965 which has a default CPU clock of 12 MHz
     syst.set_reload(12_000_000);
+    syst.clear_current();
     syst.enable_counter();
     syst.enable_interrupt();
 


### PR DESCRIPTION
To comply with `cortex-m` docs (https://docs.rs/cortex-m/0.6.0/cortex_m/peripheral/struct.SYST.html)

> NOTE The reference manual indicates that:
>
>"The SysTick counter reload and current value are undefined at reset, the correct initialization >sequence for the SysTick counter is:
>
>    Program reload value
>    Clear current value
>    Program Control and Status register"
>
>The sequence translates to self.set_reload(x); self.clear_current(); self.enable_counter()

I think this just slipped through, since the other example on systick does that.