### PR TITLE
install/verify: fix next section link

### DIFF
--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -45,7 +45,7 @@ The contents may not match exactly but you should get the last line about
 breakpoints and watchpoints. If you got it then terminate the OpenOCD process
 and move to the [next section].
 
-[next section]: ../../../start/index.md
+[next section]: ../../start/index.md
 
 If you didn't get the "breakpoints" line then try the following command.
 

--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -45,7 +45,7 @@ The contents may not match exactly but you should get the last line about
 breakpoints and watchpoints. If you got it then terminate the OpenOCD process
 and move to the [next section].
 
-[next section]: ../hardware.md
+[next section]: ../../../start/index.md
 
 If you didn't get the "breakpoints" line then try the following command.
 


### PR DESCRIPTION
The next section in the book is the "Getting Started", not the already
seen section Hardware in the same chapter.

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>