### PR TITLE
Fixup book CI

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,11 +4,10 @@ main() {
     local tag=$(git ls-remote --tags --refs --exit-code \
                     https://github.com/rust-lang-nursery/mdbook \
                         | cut -d/ -f3 \
-                        | grep -E '^v[0.1.0-9.]+$' \
+                        | grep -E '^v[0-9\.]+$' \
                         | sort --version-sort \
                         | tail -n1)
-    # Temporarily use older version until packages are available for 0.2.2 (or newer)
-    local tag="v0.2.1"
+
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- --git rust-lang-nursery/mdbook --tag $tag
 


### PR DESCRIPTION
mdbook now has binary releases: https://github.com/rust-lang-nursery/mdBook/releases

Edit:

closes https://github.com/rust-embedded/book/issues/59