### PR TITLE
Adds cargo-generate to installation instructions

### DIFF
--- a/src/intro/install.md
+++ b/src/intro/install.md
@@ -47,6 +47,14 @@ $ cargo install cargo-binutils
 $ rustup component add llvm-tools-preview
 ```
 
+### `cargo-generate`
+
+We'll use this later to generate a project from a template.
+
+``` console
+$ cargo install cargo-generate
+```
+
 ### OS-Specific Instructions
 
 Now follow the instructions specific to the OS you are using:


### PR DESCRIPTION
Fixes #186
Related to 753d71ac, which added instructions close to use in the qemu
page, this commit adds the information directly to install where it's
less likely to be overlooked.