### PR TITLE
Add hint on memory config to GDB debugging section

### DIFF
--- a/src/start/hardware.md
+++ b/src/start/hardware.md
@@ -219,6 +219,11 @@ Breakpoint 1, main () at examples/hello.rs:15
 15          let mut stdout = hio::hstdout().unwrap();
 ```
 
+> **NOTE** If GDB blocks the terminal instead of hitting the breakpoint after
+> you issue the `continue` command above, you might want to double check that
+> the memory region information in the `memory.x` file is correctly set up
+> for your device (both the starts *and* lengths). 
+
 Advancing the program with `next` should produce the same results as before.
 
 ``` console


### PR DESCRIPTION
If `memory.x` is misconfigured, the hello example can potentially still be built and flashed, only to fail without a proper error message when the user attempts to continue to the main breakpoint during the debugging section, as exemplified by #199 .

This PR adds a note after the relevant step, directing the user to examine `memory.x` for errors.