### PR TITLE
Fix `impl Gpio` -> `impl GpioConfig`

### DIFF
--- a/src/static-guarantees/design-contracts.md
+++ b/src/static-guarantees/design-contracts.md
@@ -25,7 +25,7 @@ struct GpioConfig {
     periph: GPIO_CONFIG,
 }
 
-impl Gpio {
+impl GpioConfig {
     pub fn set_enable(&mut self, is_enabled: bool) {
         self.periph.modify(|_r, w| {
             w.enable().set_bit(is_enabled)

--- a/src/static-guarantees/state-machines.md
+++ b/src/static-guarantees/state-machines.md
@@ -60,7 +60,7 @@ struct GpioConfig {
     periph: GPIO_CONFIG,
 }
 
-impl Gpio {
+impl GpioConfig {
     pub fn set_enable(&mut self, is_enabled: bool) {
         self.periph.modify(|_r, w| {
             w.enable().set_bit(is_enabled)


### PR DESCRIPTION
In the two sections "Peripherals as State Machines" and "Design
Contracts" of the "Static Guarantees" chapter, `impl Gpio` was
incorrectly used in place of `impl GpioConfig` at one place in each
section.