### PR TITLE
Replace nursery links with rust-lang links

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -2,14 +2,14 @@ set -euxo pipefail
 
 main() {
     local tag=$(git ls-remote --tags --refs --exit-code \
-                    https://github.com/rust-lang-nursery/mdbook \
+                    https://github.com/rust-lang/mdbook \
                         | cut -d/ -f3 \
                         | grep -E '^v[0-9\.]+$' \
                         | sort --version-sort \
                         | tail -n1)
 
     curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- --git rust-lang-nursery/mdbook --tag $tag
+        sh -s -- --git rust-lang/mdbook --tag $tag
 
     pip install linkchecker --user
 }

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,15 +4,13 @@ main() {
     mdbook build
     mdbook test
 
-    # FIXME(rust-lang/mdbook#789) remove `--ignore-url` when that bug is fixed
-    linkchecker --ignore-url "print.html" book
+    linkchecker book
 
     # now check this as a directory of the bookshelf
     rm -rf shelf
     mkdir shelf
     mv book shelf
-    # FIXME(rust-lang/mdbook#789) remove `--ignore-url` when that bug is fixed
-    linkchecker --ignore-url "print.html" shelf
+    linkchecker shelf
 
     mv shelf/book .
     rmdir shelf

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,14 +4,14 @@ main() {
     mdbook build
     mdbook test
 
-    # FIXME(rust-lang-nursery/mdbook#789) remove `--ignore-url` when that bug is fixed
+    # FIXME(rust-lang/mdbook#789) remove `--ignore-url` when that bug is fixed
     linkchecker --ignore-url "print.html" book
 
     # now check this as a directory of the bookshelf
     rm -rf shelf
     mkdir shelf
     mv book shelf
-    # FIXME(rust-lang-nursery/mdbook#789) remove `--ignore-url` when that bug is fixed
+    # FIXME(rust-lang/mdbook#789) remove `--ignore-url` when that bug is fixed
     linkchecker --ignore-url "print.html" shelf
 
     mv shelf/book .

--- a/src/interoperability/c-with-rust.md
+++ b/src/interoperability/c-with-rust.md
@@ -87,7 +87,7 @@ Rather than manually generating these interfaces, which may be tedious and error
   `--ctypes-prefix=cty` and `Builder.use_core()` to make the generated code `#![no_std]` compatible.
 4. `bindgen` will produce the generated Rust code to the output of the terminal window. This file may be piped to a file in your project, such as `bindings.rs`. You may use this file in your Rust project to interact with C/C++ code compiled and linked as an external library. Tip: don't forget to use the [`cty`](https://crates.io/crates/cty) crate if your types in the generated bindings are prefixed with `cty`.
 
-[bindgen]: https://github.com/rust-lang-nursery/rust-bindgen
+[bindgen]: https://github.com/rust-lang/rust-bindgen
 [bindgen user's manual]: https://rust-lang.github.io/rust-bindgen/
 
 ## Building your C/C++ code


### PR DESCRIPTION
Both repos have been moved to the `rust-lang` org and the links are
still redirecting properly. This way we just avoid the redirect and make
the link shorter.