### PR TITLE
Add a Glossary appendix page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -46,3 +46,7 @@ more information and coordination
     - [A little Rust with your C](./interoperability/rust-with-c.md)
 - [Unsorted topics](./unsorted/index.md)
   - [Optimizations: The speed size tradeoff](./unsorted/speed-vs-size.md)
+
+---
+
+[Appendix A: Glossary](./appendix/glossary.md)

--- a/src/appendix/glossary.md
+++ b/src/appendix/glossary.md
@@ -1,0 +1,16 @@
+# Appendix A: Glossary
+
+The embedded ecosystem is full of different protocols, hardware components and
+vendor-specific things that use their own terms and abbreviations. This Glossary
+attempts to list them with pointers for understanding them better.
+
+Term         | Meaning
+-------------|--------
+I2C          | Sometimes referred to as `I² C` or Inter-IC. It is a protocol meant for hardware communication within a single integrated circuit. See [i2c.info] for more details
+SPI          | Serial Peripheral Interface
+USART        | Universal synchronous and asynchronous receiver-transmitter
+UART         | Universal asynchronous receiver-transmitter
+FPU          | Floating-point Unit. A 'math processor' running only operations on floating-point numbers
+PAC          | Peripheral Access Crate
+
+[i2c.info]: https://i2c.info/


### PR DESCRIPTION
Same structure as the [rustc-guide] basically.

I added some initial abbreviations and hope the explanations are correct.
I think it would be nice to get this merged without much iteration, so other people can start filling things in, too.

Closes #220

[rustc-guide]: https://rust-lang.github.io/rustc-guide/appendix/glossary.html#appendix-c-glossary