### PR TITLE
Setting output to `high` needs a `true` argument

### DIFF
--- a/src/static-guarantees/design-contracts.md
+++ b/src/static-guarantees/design-contracts.md
@@ -239,7 +239,7 @@ let pin_state = pulled_low.bit_is_set();
  * Example 3: Pulled Low input to Output, set high
  */
 let output_pin = pulled_low.into_enabled_output();
-output_pin.set_bit(false);
+output_pin.set_bit(true);
 
 // Can't do this, output pins don't have this interface!
 // output_pin.into_input_pull_down();


### PR DESCRIPTION
See the comment in line 239.