### PR TITLE
QEMU debugging updates

### DIFF
--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -17,7 +17,7 @@ ST-LINK header is circled in red.
 Now run the following command:
 
 ``` console
-$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+$ openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 You should get the following output and the program should block the console:

--- a/src/intro/install/windows.md
+++ b/src/intro/install/windows.md
@@ -16,13 +16,13 @@ GNU gdb (GNU Tools for Arm Embedded Processors 7-2018-q2-update) 8.1.0.20180315-
 
 ## OpenOCD
 
-There's no official binary release of OpenOCD for Windows but there are unofficial releases
-available [here][openocd]. Grab the 0.10.x zipfile and extract it somewhere on your drive (I
-recommend `C:\OpenOCD` but with the drive letter that makes sense to you) then update your `%PATH%`
-environment variable to include the following path: `C:\OpenOCD\bin` (or the path that you used
-before).
+There's no official binary release of OpenOCD for Windows but if you're not in the mood to compile
+it yourself, the xPack project provides a binary distribution, [here][openocd]. Follow the
+provided installation instructions. Then update your `%PATH%` environment variable to
+include the path where the binaries were installed. (`C:\Users\USERNAME\AppData\Roaming\xPacks\@xpack-dev-tools\openocd\0.10.0-13.1\.content\bin\`,
+if you've been using the easy install) 
 
-[openocd]: https://github.com/gnu-mcu-eclipse/openocd/releases
+[openocd]: https://xpack.github.io/openocd/
 
 Verify that OpenOCD is in your `%PATH%` with:
 


### PR DESCRIPTION
Addressing a few issues:
Fixes #237, Fixes #234, Fixes #217 

The biggest issue this PR is addressing is correcting the "debugging QEMU with GDB" section that really didn't work with latest ARM toolchain (on my setup), because of two things:
 - gdb didn't map the rust libcore functions properly.  For example, after connecting to a QEMU instance, it did not show the current PC to be on the Reset function, but some random method.  
 - gdb didn't step over (`next`), after breaking at `main`. It just ran to the end of the program.

The user is now instructed to disable the LDD and use the GNU ARM linker instead, which addresses the issues with the mapping.

And instead of doing a simple, `break main`  which did not allow the user to step over after hitting the breakpoint, the user is now guided to do a more complicated,
`break hello::__cortex_m_rt_main`. After hitting that breakpoint, the `next` and `step` commands are working as one would expect.

I am no expert in embedded rust, so the proposed solution may not be optimal, but I think they are better than the current instructions provided by the book which are not working at all on my setup. (Windows 10, with latest versions of QEMU, ARM toolchain, Rust) 

