### PR TITLE
Provide a note on 'extern crate' usage in edition 2018 syntax of Rust

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -62,7 +62,7 @@ times it has been called in the `COUNT` variable and then prints the value of
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use core::fmt::Write;
 
@@ -190,7 +190,7 @@ memory location.
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use core::fmt::Write;
 use core::ptr;

--- a/src/start/panicking.md
+++ b/src/start/panicking.md
@@ -51,11 +51,11 @@ profile. For example:
 
 // dev profile: easier to debug panics; can put a breakpoint on `rust_begin_unwind`
 #[cfg(debug_assertions)]
-extern crate panic_halt;
+use panic_halt as _;
 
 // release profile: minimize the binary size of the application
 #[cfg(not(debug_assertions))]
-extern crate panic_abort;
+use panic_abort as _;
 
 // ..
 ```
@@ -63,6 +63,12 @@ extern crate panic_abort;
 In this example the crate links to the `panic-halt` crate when built with the
 dev profile (`cargo build`), but links to the `panic-abort` crate when built
 with the release profile (`cargo build --release`).
+
+> Note that the _underscore import_ form of the _use_ declaration is used to import a `#[panic_handler]` function
+> symbol without importing of trait's symbol itself since it is not used elsewhere on its own.
+> Sometimes you might see the `extern crate` form of importing which is used for the same reason but it is unidiomatic.
+> `extern crate` should be used only for importing _"sysroot"_ crates (crates distributed with Rust itself) like `proc_macro`,
+> `alloc`, `test`, and similar ones.
 
 ## An example
 
@@ -73,7 +79,7 @@ results in a panic.
 #![no_main]
 #![no_std]
 
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use cortex_m_rt::entry;
 

--- a/src/start/panicking.md
+++ b/src/start/panicking.md
@@ -64,11 +64,12 @@ In this example the crate links to the `panic-halt` crate when built with the
 dev profile (`cargo build`), but links to the `panic-abort` crate when built
 with the release profile (`cargo build --release`).
 
-> Note that the _underscore import_ form of the _use_ declaration is used to import a `#[panic_handler]` function
-> symbol without importing of trait's symbol itself since it is not used elsewhere on its own.
-> Sometimes you might see the `extern crate` form of importing which is used for the same reason but it is unidiomatic.
-> `extern crate` should be used only for importing _"sysroot"_ crates (crates distributed with Rust itself) like `proc_macro`,
-> `alloc`, `test`, and similar ones.
+> The `use panic_abort as _;` form of the `use` statement is used to ensure the `panic_abort` panic handler is
+> included in our final executable while making it clear to the compiler that we won't explicitly use anything from
+> the crate. Without the `as _` rename, the compiler would warn that we have an unused import.
+> Sometimes you might see `extern crate panic_abort` instead, which is an older style used before the
+> 2018 edition of Rust, and should now only be used for "sysroot" crates (those distributed with Rust itself) such
+> as `proc_macro`, `alloc`, `std`, and `test`.
 
 ## An example
 

--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -121,6 +121,9 @@ nightly.
 the panicking behavior of the program. We will cover this in more detail in the
 [Panicking](panicking.md) chapter of the book.
 
+> Note that while `extern crate` looks odd in modern Rust syntax, this declaration
+> form is required since it resolves the implicit dependency in `no_std` context.
+
 [`#[entry]`][entry] is an attribute provided by the [`cortex-m-rt`] crate that's used
 to mark the entry point of the program. As we are not using the standard `main`
 interface we need another way to indicate the entry point of the program and

--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -94,7 +94,7 @@ For convenience here are the most important parts of the source code in `src/mai
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m_rt::entry;
 
@@ -117,12 +117,9 @@ interface that most Rust programs use. The main (no pun intended) reason to go
 with `no_main` is that using the `main` interface in `no_std` context requires
 nightly.
 
-`extern crate panic_halt;`. This crate provides a `panic_handler` that defines
+`use panic_halt as _;`. This crate provides a `panic_handler` that defines
 the panicking behavior of the program. We will cover this in more detail in the
 [Panicking](panicking.md) chapter of the book.
-
-> Note that while `extern crate` looks odd in modern Rust syntax, this declaration
-> form is required since it resolves the implicit dependency in `no_std` context.
 
 [`#[entry]`][entry] is an attribute provided by the [`cortex-m-rt`] crate that's used
 to mark the entry point of the program. As we are not using the standard `main`
@@ -321,7 +318,7 @@ For convenience here's the source code of `examples/hello.rs`:
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};
@@ -512,7 +509,7 @@ list main
 This will show the source code, from the file examples/hello.rs. 
 
 ```text
-6       extern crate panic_halt;
+6       use panic_halt as _;
 7
 8       use cortex_m_rt::entry;
 9       use cortex_m_semihosting::{debug, hprintln};

--- a/src/start/registers.md
+++ b/src/start/registers.md
@@ -53,7 +53,7 @@ We won't get very far with our embedded software development if we restrict ours
 #![no_std]
 #![no_main]
 
-extern crate panic_halt; // panic handler
+use panic_halt as _; // panic handler
 
 use cortex_m_rt::entry;
 use tm4c123x;
@@ -129,7 +129,7 @@ Let's see an example:
 #![no_std]
 #![no_main]
 
-extern crate panic_halt; // panic handler
+use panic_halt as _; // panic handler
 
 use cortex_m_rt::entry;
 use tm4c123x_hal as hal;

--- a/src/start/semihosting.md
+++ b/src/start/semihosting.md
@@ -16,7 +16,7 @@ world!":
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m_rt::entry;
 use cortex_m_semihosting::hprintln;
@@ -67,7 +67,7 @@ until you restart it.
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+use panic_halt as _;
 
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
@@ -105,7 +105,7 @@ stderr.
 #![no_main]
 #![no_std]
 
-extern crate panic_semihosting; // features = ["exit"]
+use panic_semihosting as _; // features = ["exit"]
 
 use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;


### PR DESCRIPTION
I was confused reading 'extern crate' in the examples of the book since it looks like old Rust syntax and encounters quite rare nowadays. So it is looked like not-updated. I saw an [issue](https://github.com/rust-embedded/book/issues/41) which tells that other people also had same thoughts. So my change is to make it clear that usage of this declaration form is intended and not-updated.