### PR TITLE
Note on transformation of static variables by attribute exception

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -49,7 +49,7 @@ possible.
 
 > Note that the `exception` attribute transforms definitions of static variables
 > inside the function by wrapping them into `unsafe` blocks and providing us
-> with new appropriate variables of type `&mut` which names match user defined.
+> with new appropriate variables of type `&mut` of the same name.
 > Thus we can use operator `*` to access the values of the variables without
 > need to wrap them into the `unsafe` blocks.
 

--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -51,7 +51,7 @@ possible.
 > inside the function by wrapping them into `unsafe` blocks and providing us
 > with new appropriate variables of type `&mut` of the same name.
 > Thus we can use operator `*` to access the values of the variables without
-> need to wrap them into the `unsafe` blocks.
+> needing to wrap them in an `unsafe` block.
 
 ## A complete example
 

--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -47,11 +47,11 @@ use `static mut` variables. How is this possible? This is possible because
 `exception` handlers can *not* be called by software thus reentrancy is not
 possible.
 
-> Note that the `exception` attribute makes transformation of static variables
-> inside the function by wrapping the static variable definitions into `unsafe`
-> blocks and providing us with new appropriate variables of type `&mut` which
-> names match user defined. Thus we can use operator `*` to access the values
-> of the variables without need to wrap them into the `unsafe` blocks.
+> Note that the `exception` attribute transforms definitions of static variables
+> inside the function by wrapping them into `unsafe` blocks and providing us
+> with new appropriate variables of type `&mut` which names match user defined.
+> Thus we can use operator `*` to access the values of the variables without
+> need to wrap them into the `unsafe` blocks.
 
 ## A complete example
 

--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -50,7 +50,7 @@ possible.
 > Note that the `exception` attribute transforms definitions of static variables
 > inside the function by wrapping them into `unsafe` blocks and providing us
 > with new appropriate variables of type `&mut` of the same name.
-> Thus we can use operator `*` to access the values of the variables without
+> Thus we can derefence the reference via `*` to access the values of the variables without
 > needing to wrap them in an `unsafe` block.
 
 ## A complete example

--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -31,7 +31,7 @@ This behavior is pretty much intended and it's required to provide a feature:
 fn SysTick() {
     static mut COUNT: u32 = 0;
 
-    // `COUNT` has type `&mut u32` and it's safe to use
+    // `COUNT` has transformed to type `&mut u32` and it's safe to use
     *COUNT += 1;
 }
 ```
@@ -46,6 +46,12 @@ must be marked as `unsafe`. Yet I just told that `exception` handlers can safely
 use `static mut` variables. How is this possible? This is possible because
 `exception` handlers can *not* be called by software thus reentrancy is not
 possible.
+
+> Note that the `exception` attribute makes transformation of static variables
+> inside the function by wrapping the static variable definitions into `unsafe`
+> blocks and providing us with new appropriate variables of type `&mut` which
+> names match user defined. Thus we can use operator `*` to access the values
+> of the variables without need to wrap them into the `unsafe` blocks.
 
 ## A complete example
 


### PR DESCRIPTION
Hi All
The "// `COUNT` has type `&mut u32` and it's safe to use" comment confused me since I did not expect that transformation of the source code so deep comparing with the C language.
Finally I found how it (works)[https://docs.rs/cortex-m-rt-macros/0.1.5/src/cortex_m_rt_macros/lib.rs.html#447].
This PR is to provide a note about the transformation.
Thanks, Slava