### PR TITLE
Add additional command to try when verifying installation.

### DIFF
--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -47,18 +47,22 @@ and move to the [next section].
 
 [next section]: ../../start/index.md
 
-If you didn't get the "breakpoints" line then try the following command.
+If you didn't get the "breakpoints" line then try one of the following commands.
 
 ``` console
 $ openocd -f interface/stlink-v2.cfg -f target/stm32f3x.cfg
 ```
 
-If that command works that means you got an old hardware revision of the
+``` console
+$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+```
+
+If one of those commands works it means you got an old hardware revision of the
 discovery board. That won't be a problem but commit that fact to memory as
 you'll need to configure things a bit differently later on. You can move to the
 [next section].
 
-If neither command worked as a normal user then try to run them with root
+If none of the commands work as a normal user then try to run them with root
 permission (e.g. `sudo openocd ..`). If the commands do work with root
 permission then check that the [udev rules] have been correctly set.
 


### PR DESCRIPTION
The given commands didn't work for me, so I looked through my system for a similarly-named file and found `interface/stlink-v2-1.cfg`. When I tried that I ended up getting the breakpoints result mentioned.

One thing I'm still a little confused about is the mention of having an older revision of the board. I don't think I have an old version because I bought it recently and my PCB says "MB1035D" next to the STM32 chip. It might be due to having a newer distribution of OpenOCD because it doesn't have any files named `stlink.cfg`, only `stlink-v1.cfg`, `stlink-v2.cfg`, and `stlink-v2-1.cfg`. I didn't want to make any changes to the rest of the description, though, because it doesn't change the fact it's something that you need to keep in mind later (I assume, I'm just starting the book), and I don't feel I understand enough at this point to make that decision.