### PR TITLE
Ignore unused argument in closure

### DIFF
--- a/src/static-guarantees/state-machines.md
+++ b/src/static-guarantees/state-machines.md
@@ -68,7 +68,7 @@ impl GpioConfig {
     }
 
     pub fn set_direction(&mut self, is_output: bool) {
-        self.periph.modify(|r, w| {
+        self.periph.modify(|_r, w| {
             w.direction().set_bit(is_output)
         });
     }


### PR DESCRIPTION
I'm fairly new to Rust so perhaps I'm overlooking something. But I think this argument should be ignored like the other `_r`'s, right?