### PR TITLE
Fix openocd command in Verify Installation section.

### DIFF
--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -17,7 +17,7 @@ ST-LINK header is circled in red.
 Now run the following command:
 
 ``` console
-$ openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
+$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
 ```
 
 You should get the following output and the program should block the console:


### PR DESCRIPTION
For the recent STM32F303VCT6, it should refer interface/stlink-v2-1.cfg.
Same as in https://github.com/rust-embedded/cortex-m-quickstart/blob/be44af69cc91e2ff5b75f400e09488cba44e9f59/openocd.cfg#L7
Otherwise, using the currently specified interface/stlink.cfg produces openocd error:
```
Error: open failed
in procedure 'init'
in procedure 'ocd_bouncer'
```