### PR TITLE
llvm-objdump: Use two hyphens in flags to objdump

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -249,7 +249,7 @@ If you look at the disassembly of the program:
 
 
 ``` console
-$ cargo objdump --bin app --release -- -d -no-show-raw-insn -print-imm-hex
+$ cargo objdump --bin app --release -- -d --no-show-raw-insn --print-imm-hex
 (..)
 ResetTrampoline:
  8000942:       movw    r0, #0xfffe

--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -259,8 +259,11 @@ is.
 `cargo-objdump` can be used to disassemble the binary.
 
 ```console
-cargo objdump --bin app --release -- -disassemble -no-show-raw-insn -print-imm-hex
+cargo objdump --bin app --release -- --disassemble --no-show-raw-insn --print-imm-hex
 ```
+
+> **NOTE** if the above command complains about `Unknown command line argument` see
+> the following bug report: https://github.com/rust-embedded/book/issues/269
 
 > **NOTE** this output can differ on your system. New versions of rustc, LLVM
 > and libraries can generate different assembly. We truncated some of the instructions


### PR DESCRIPTION
LLVM 11 changed the behavior of these tools.
See https://github.com/rust-embedded/book/issues/269