### PR TITLE
book.toml: add link to GitHub repo

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,3 +3,6 @@ authors = ["James Munns"]
 multilingual = false
 src = "src"
 title = "The Embedded Rust Book"
+
+[output.html]
+git-repository-url = "https://github.com/rust-embedded/book"


### PR DESCRIPTION
This will show a GitHub icon in the website that links to the repo