### PR TITLE
Fix installing dateutil since it is now a dependency of the GHP import script

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,6 +11,7 @@ main() {
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- --git rust-lang/mdbook --tag $tag
 
+    pip install python-dateutil --user
     pip install linkchecker --user
 }
 


### PR DESCRIPTION
This fixes the publication even though still running on Travis CI.
See #280 