### PR TITLE
Add note about using more recent openocd interface file. Closes #277 and #263

### DIFF
--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -20,6 +20,10 @@ Now run the following command:
 $ openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
+> **NOTE**: Old versions of openocd, including the 0.10.0 release from 2017, do
+> not contain the new (and preferable) `interface/stlink.cfg` file; instead you
+> may need to use `interface/stlink-v2.cfg` or `interface/stlink-v2-1.cfg`.
+
 You should get the following output and the program should block the console:
 
 ``` text


### PR DESCRIPTION
This is a long-standing issue thanks to openocd's confusing rename of this interface file and not having a release for many years (see also #283 and #268).