### PR TITLE
Make it easier to copy and paste example commands.

### DIFF
--- a/src/intro/install.md
+++ b/src/intro/install.md
@@ -9,7 +9,7 @@ Install rustup by following the instructions at [https://rustup.rs](https://rust
 **NOTE** Make sure you have a compiler version equal to or newer than `1.31`. `rustc
 -V` should return a date newer than the one shown below.
 
-``` console
+``` text
 $ rustc -V
 rustc 1.31.1 (b6c32da9b 2018-12-18)
 ```
@@ -21,43 +21,43 @@ board used for the examples in this book, use the `thumbv7em-none-eabihf` target
 
 Cortex-M0, M0+, and M1 (ARMv6-M architecture):
 ``` console
-$ rustup target add thumbv6m-none-eabi
+rustup target add thumbv6m-none-eabi
 ```
 
 Cortex-M3 (ARMv7-M architecture):
 ``` console
-$ rustup target add thumbv7m-none-eabi
+rustup target add thumbv7m-none-eabi
 ```
 
 Cortex-M4 and M7 without hardware floating point (ARMv7E-M architecture):
 ``` console
-$ rustup target add thumbv7em-none-eabi
+rustup target add thumbv7em-none-eabi
 ```
 
 Cortex-M4F and M7F with hardware floating point (ARMv7E-M architecture):
 ``` console
-$ rustup target add thumbv7em-none-eabihf
+rustup target add thumbv7em-none-eabihf
 ```
 
 Cortex-M23 (ARMv8-M architecture):
 ``` console
-$ rustup target add thumbv8m.base-none-eabi
+rustup target add thumbv8m.base-none-eabi
 ```
 
 Cortex-M33 and M35P (ARMv8-M architecture):
 ``` console
-$ rustup target add thumbv8m.main-none-eabi
+rustup target add thumbv8m.main-none-eabi
 ```
 
 Cortex-M33F and M35PF with hardware floating point (ARMv8-M architecture):
 ``` console
-$ rustup target add thumbv8m.main-none-eabihf
+rustup target add thumbv8m.main-none-eabihf
 ```
 
 
 ### `cargo-binutils`
 
-``` console
+``` text
 $ cargo install cargo-binutils
 
 $ rustup component add llvm-tools-preview
@@ -68,7 +68,7 @@ $ rustup component add llvm-tools-preview
 We'll use this later to generate a project from a template.
 
 ``` console
-$ cargo install cargo-generate
+cargo install cargo-generate
 ```
 
 ### OS-Specific Instructions

--- a/src/intro/install/macos.md
+++ b/src/intro/install/macos.md
@@ -4,7 +4,7 @@ All the tools can be install using [Homebrew]:
 
 [Homebrew]: http://brew.sh/
 
-``` console
+``` text
 $ # GDB
 $ brew install armmbed/formulae/arm-none-eabi-gcc
 

--- a/src/intro/install/verify.md
+++ b/src/intro/install/verify.md
@@ -17,7 +17,7 @@ ST-LINK header is circled in red.
 Now run the following command:
 
 ``` console
-$ openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink.cfg -f target/stm32f3x.cfg
 ```
 
 > **NOTE**: Old versions of openocd, including the 0.10.0 release from 2017, do
@@ -54,11 +54,11 @@ and move to the [next section].
 If you didn't get the "breakpoints" line then try one of the following commands.
 
 ``` console
-$ openocd -f interface/stlink-v2.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink-v2.cfg -f target/stm32f3x.cfg
 ```
 
 ``` console
-$ openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
+openocd -f interface/stlink-v2-1.cfg -f target/stm32f3x.cfg
 ```
 
 If one of those commands works it means you got an old hardware revision of the

--- a/src/intro/install/windows.md
+++ b/src/intro/install/windows.md
@@ -6,7 +6,7 @@ ARM provides `.exe` installers for Windows. Grab one from [here][gcc], and follo
 Just before the installation process finishes tick/select the "Add path to environment variable"
 option. Then verify that the tools are in your `%PATH%`:
 
-``` console
+``` text
 $ arm-none-eabi-gdb -v
 GNU gdb (GNU Tools for Arm Embedded Processors 7-2018-q2-update) 8.1.0.20180315-git
 (..)
@@ -26,7 +26,7 @@ if you've been using the easy install)
 
 Verify that OpenOCD is in your `%PATH%` with:
 
-``` console
+``` text
 $ openocd -v
 Open On-Chip Debugger 0.10.0
 (..)

--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -121,7 +121,7 @@ fn SysTick() {
 ```
 
 ``` console
-$ tail -n5 Cargo.toml
+tail -n5 Cargo.toml
 ```
 
 ``` toml
@@ -132,7 +132,7 @@ panic-halt = "0.2.0"
 cortex-m-semihosting = "0.3.1"
 ```
 
-``` console
+``` text
 $ cargo run --release
      Running `qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb (..)
 123456789
@@ -227,7 +227,7 @@ fn HardFault(ef: &ExceptionFrame) -> ! {
 The `HardFault` handler prints the `ExceptionFrame` value. If you run this
 you'll see something like this on the OpenOCD console.
 
-``` console
+``` text
 $ openocd
 (..)
 ExceptionFrame {
@@ -248,7 +248,7 @@ and it points to the instruction that triggered the exception.
 If you look at the disassembly of the program:
 
 
-``` console
+``` text
 $ cargo objdump --bin app --release -- -d --no-show-raw-insn --print-imm-hex
 (..)
 ResetTrampoline:

--- a/src/start/hardware.md
+++ b/src/start/hardware.md
@@ -40,19 +40,19 @@ We'll start from scratch with a fresh template instance. Refer to the
 
 [previous section on QEMU]: qemu.md
 
-``` console
+``` text
 $ cargo generate --git https://github.com/rust-embedded/cortex-m-quickstart
  Project Name: app
  Creating project called `app`...
  Done! New project created /tmp/app
 
- $ cd app
+$ cd app
 ```
 
 Step number one is to set a default compilation target in `.cargo/config`.
 
 ``` console
-$ tail -n5 .cargo/config
+tail -n5 .cargo/config
 ```
 
 ``` toml
@@ -68,7 +68,7 @@ We'll use `thumbv7em-none-eabihf` as that covers the Cortex-M4F core.
 The second step is to enter the memory region information into the `memory.x`
 file.
 
-``` console
+``` text
 $ cat memory.x
 /* Linker script for the STM32F303VCT6 */
 MEMORY
@@ -107,7 +107,7 @@ and inspect the binaries using `cargo-binutils` as you did before. The
 as helpfully, pretty much all Cortex-M CPUs boot in the same fashion.
 
 ``` console
-$ cargo build --example hello
+cargo build --example hello
 ```
 
 ## Debugging
@@ -131,7 +131,7 @@ Run this command from the root of the template; `openocd` will pick up the
 `openocd.cfg` file which indicates which interface file and target file to use.
 
 ``` console
-$ cat openocd.cfg
+cat openocd.cfg
 ```
 
 ``` text
@@ -153,7 +153,7 @@ source [find target/stm32f3x.cfg]
 > board during the [verify] section then you should modify the `openocd.cfg`
 > file at this point to use `interface/stlink-v2.cfg`.
 
-``` console
+``` text
 $ openocd
 Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
@@ -175,7 +175,7 @@ Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
 
 On another terminal run GDB, also from the root of the template.
 
-``` console
+``` text
 $ <gdb> -q target/thumbv7em-none-eabihf/debug/examples/hello
 ```
 
@@ -243,7 +243,7 @@ Advancing the program with `next` should produce the same results as before.
 At this point you should see "Hello, world!" printed on the OpenOCD console,
 among other stuff.
 
-``` console
+``` text
 $ openocd
 (..)
 Info : halted: PC: 0x08000e6c
@@ -269,7 +269,7 @@ Program received signal SIGTRAP, Trace/breakpoint trap.
 
 It also causes this to be printed to the OpenOCD console:
 
-``` console
+``` text
 $ openocd
 (..)
 Info : halted: PC: 0x08001188
@@ -293,7 +293,7 @@ Debugging now requires a few more steps so we have packed all those steps into a
 single GDB script named `openocd.gdb`. The file was created during the `cargo generate` step, and should work without any modifications. Let's have a peak:
 
 ``` console
-$ cat openocd.gdb
+cat openocd.gdb
 ```
 
 ``` text
@@ -323,7 +323,7 @@ Alternatively, you can turn `<gdb> -x openocd.gdb` into a custom runner to make
 in `.cargo/config` but it's commented out.
 
 ``` console
-$ head -n10 .cargo/config
+head -n10 .cargo/config
 ```
 
 ``` toml
@@ -339,7 +339,7 @@ runner = "arm-none-eabi-gdb -x openocd.gdb"
 # runner = "gdb -x openocd.gdb"
 ```
 
-``` console
+``` text
 $ cargo run --example hello
 (..)
 Loading section .vector_table, size 0x400 lma 0x8000000

--- a/src/start/panicking.md
+++ b/src/start/panicking.md
@@ -97,7 +97,7 @@ fn main() -> ! {
 This example chose the `panic-semihosting` behavior which prints the panic
 message to the host console using semihosting.
 
-``` console
+``` text
 $ cargo run
      Running `qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb (..)
 panicked at 'index out of bounds: the len is 3 but the index is 4', src/main.rs:12:13

--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -158,7 +158,7 @@ To cross compile for the Cortex-M3 architecture we have to use
 the Rust toolchain, it would now be a good time to add that target to the toolchain,
 if you haven't done it yet:
 ``` console
-$ rustup target add thumbv7m-none-eabi
+rustup target add thumbv7m-none-eabi
 ```
  Since the `thumbv7m-none-eabi` compilation target has been set as the default in 
  your `.cargo/config` file, the two commands below do the same:

--- a/src/start/semihosting.md
+++ b/src/start/semihosting.md
@@ -32,7 +32,7 @@ fn main() -> ! {
 If you run this program on hardware you'll see the "Hello, world!" message
 within the OpenOCD logs.
 
-``` console
+``` text
 $ openocd
 (..)
 Hello, world!
@@ -51,7 +51,7 @@ need to pass the `-semihosting-config` flag to QEMU to enable semihosting
 support; these flags are already included in the `.cargo/config` file of the
 template.
 
-``` console
+``` text
 $ # this program will block the terminal
 $ cargo run
      Running `qemu-system-arm (..)
@@ -86,7 +86,7 @@ fn main() -> ! {
 }
 ```
 
-``` console
+``` text
 $ cargo run
      Running `qemu-system-arm (..)
 
@@ -120,7 +120,7 @@ fn main() -> ! {
 }
 ```
 
-``` console
+``` text
 $ cargo run
      Running `qemu-system-arm (..)
 panicked at 'assertion failed: `(left == right)`

--- a/src/unsorted/speed-vs-size.md
+++ b/src/unsorted/speed-vs-size.md
@@ -58,7 +58,7 @@ opt-level = "z" # +
 
 Without the override:
 
-``` console
+``` text
 $ cargo size --bin app -- -A
 app  :
 section               size        addr
@@ -71,7 +71,7 @@ section               size        addr
 
 With the override:
 
-``` console
+``` text
 $ cargo size --bin app -- -A
 app  :
 section               size        addr


### PR DESCRIPTION
Remove $ prompt for commands that could be copied & pasted.  Change
``` console to ``` text for command examples that include output.