### PR TITLE
Remove $ from cargo-binutils

### DIFF
--- a/src/intro/install.md
+++ b/src/intro/install.md
@@ -58,9 +58,9 @@ rustup target add thumbv8m.main-none-eabihf
 ### `cargo-binutils`
 
 ``` text
-$ cargo install cargo-binutils
+cargo install cargo-binutils
 
-$ rustup component add llvm-tools-preview
+rustup component add llvm-tools-preview
 ```
 
 ### `cargo-generate`


### PR DESCRIPTION
Currently the copy/paste wont work on this particular one because it copies the `$` as well and then the users console will throw an error