### PR TITLE
Make glossary more linkable and add more detail

### DIFF
--- a/src/appendix/glossary.md
+++ b/src/appendix/glossary.md
@@ -4,13 +4,52 @@ The embedded ecosystem is full of different protocols, hardware components and
 vendor-specific things that use their own terms and abbreviations. This Glossary
 attempts to list them with pointers for understanding them better.
 
-Term         | Meaning
--------------|--------
-I2C          | Sometimes referred to as `I² C` or Inter-IC. It is a protocol meant for hardware communication within a single integrated circuit. See [i2c.info] for more details
-SPI          | Serial Peripheral Interface
-USART        | Universal synchronous and asynchronous receiver-transmitter
-UART         | Universal asynchronous receiver-transmitter
-FPU          | Floating-point Unit. A 'math processor' running only operations on floating-point numbers
-PAC          | Peripheral Access Crate
+### BSP
+
+A Board Support Crate provides a high level interface configured for a specific developer
+board. It usually depends on a [HAL](#hal) crate.
+There is a more detailed description on the [memory mapper registers page](../start/registers.md).
+
+### FPU
+
+Floating-point Unit. A 'math processor' running only operations on floating-point numbers.
+
+### HAL
+
+A Hardware Abstraction Layer crate provides a developer friendly interface to a microcontroller's
+features and peripherals. It is usually implemented on top of a [Peripheral Access Crate (PAC)](#pac).
+It may also implement traits from the [`embedded-hal`](https://crates.io/crates/embedded-hal) crate.
+There is a more detailed description on the [memory mapper registers page](../start/registers.md).
+
+### I2C
+
+Sometimes referred to as `I² C` or Inter-IC. It is a protocol meant for hardware communication
+within a single integrated circuit. See [i2c.info] for more details
 
 [i2c.info]: https://i2c.info/
+
+### PAC
+
+A Peripheral Access Crate provides access to a microcontroller's peripherals. It is one of
+the lower level crates and is usually generated directly from the provided [SVD](#svd), often
+using [svd2rust](https://github.com/rust-embedded/svd2rust/). The [Hardware Abstraction Layer](#hal)
+would usually depend on this crate.
+There is a more detailed description on the [memory mapper registers page](../start/registers.md).
+
+### SPI
+
+Serial Peripheral Interface
+
+### SVD
+
+System View Description is an XML file format used to describe the programmers view of a
+microcontroller device. You can read more about it on
+[the ARM CMSIS documentation site](https://www.keil.com/pack/doc/CMSIS/SVD/html/index.html).
+
+### UART
+
+Universal asynchronous receiver-transmitter
+
+### USART
+
+Universal synchronous and asynchronous receiver-transmitter


### PR DESCRIPTION
While writing a blog post I found that I wanted to be able to link to a common definition of certain terms but I was not able to find one.

This changes makes the glossary up from sub-headings so that each item can be linked to directly. I have also filled out some more detail on the areas I'm particularly interested in (BSP, HAL and PAC).

Things I'm not sure about:
- I am very new to embedded development so please review what I've written carefully, it may not be correct.
- I'm not sure how much detail to put here as there seems to be a bit of overlap with the [registers page](https://docs.rust-embedded.org/book/start/registers.html). I've gone with more detail here because I would like to link to these definitions from outside this book.