### PR TITLE
2.1(QEMU): update app name for git project init

### DIFF
--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -58,13 +58,13 @@ And then fill in the placeholders in the `Cargo.toml` file
 [package]
 authors = ["{{authors}}"] # "{{authors}}" -> "John Smith"
 edition = "2018"
-name = "{{project-name}}" # "{{project-name}}" -> "awesome-app"
+name = "{{project-name}}" # "{{project-name}}" -> "app"
 version = "0.1.0"
 
 # ..
 
 [[bin]]
-name = "{{project-name}}" # "{{project-name}}" -> "awesome-app"
+name = "{{project-name}}" # "{{project-name}}" -> "app"
 test = false
 bench = false
 ```


### PR DESCRIPTION
**What this PR seeks to solve:**
this isn't a huge problem, but only the "Using `git`" section of the book uses
the application name 'awesome-app', which doesn't align with the other
startup sections/commands that follow this section. the workaround is to use
'awesome-app' in lieu of 'app' in commands like `cargo size`.

**Changes:**
update application name in the `Using git` section from `awesome-app`
to `app` to follow along with the rest of the initialization instructions/subsequent
sections of the book. this change is meant to make it easier to follow
instructions that follow this section in the book that use the name of the application