### PR TITLE
Change `-file-headers` to `--file-headers`

### DIFF
--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -177,7 +177,7 @@ With `cargo-readobj` we can print the ELF headers to confirm that this is an ARM
 binary.
 
 ``` console
-cargo readobj --bin app -- -file-headers
+cargo readobj --bin app -- --file-headers
 ```
 
 Note that:


### PR DESCRIPTION
Running `cargo readobj --bin app -- -file-headers` will fail because of the missing hyphen.