### PR TITLE
"linker `link.exe` not found" fix

### DIFF
--- a/src/intro/install.md
+++ b/src/intro/install.md
@@ -62,7 +62,7 @@ cargo install cargo-binutils
 
 rustup component add llvm-tools-preview
 ```
-
+WINDOWS: prerequisite C++ Build Tools for Visual Studio 2019 is installed. https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16 
 ### `cargo-generate`
 
 We'll use this later to generate a project from a template.


### PR DESCRIPTION
Warned windows users that they need C++ visual studio tools. 
If not installed cargo with complain "linker `link.exe` not found". 
Included /visualstudio.microsoft.com link