### PR TITLE
Improved ligability for hardware.md

### DIFF
--- a/src/start/hardware.md
+++ b/src/start/hardware.md
@@ -176,8 +176,12 @@ Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
 On another terminal run GDB, also from the root of the template.
 
 ``` text
-$ <gdb> -q target/thumbv7em-none-eabihf/debug/examples/hello
+gdb-multiarch -q target/thumbv7em-none-eabihf/debug/examples/hello
 ```
+
+**NOTE**: like before you might need another version of gdb instead of `gdb-multiarch` depending
+on which one you installed in the installation chapter. This could also be
+`arm-none-eabi-gdb` or just `gdb`.
 
 Next connect GDB to OpenOCD, which is waiting for a TCP connection on port 3333.
 


### PR DESCRIPTION
When following Section 2.2 Hardware, I would get stuck trying to launch `gdp`  but wouldn't get stuck in section 2.1 QEMU. There is a disparity between the two sections of code even though they achieving the same function. 
My suggestion is to warn the user about the different versions of `gdp` vs `gdb-multiarch`  in the same fashion as the QEMU section.