### PR TITLE
doc: Fix `arm-none-eabi-gdb` installation instruction for Fedora 27 or newer to just use `gdb`

### DIFF
--- a/src/intro/install/linux.md
+++ b/src/intro/install/linux.md
@@ -39,16 +39,13 @@ sudo apt install gdb-arm-none-eabi openocd qemu-system-arm
 
 - Fedora 27 or newer
 
-> **NOTE** `arm-none-eabi-gdb` is the GDB command you'll use to debug your ARM
-> Cortex-M programs
-
 <!-- Fedora 27 -->
 <!-- GDB 7.6 (!) -->
 <!-- OpenOCD 0.10.0 -->
 <!-- QEMU 2.10.2 -->
 
 ``` console
-sudo dnf install arm-none-eabi-gdb openocd qemu-system-arm
+sudo dnf install gdb openocd qemu-system-arm
 ```
 
 - Arch Linux


### PR DESCRIPTION
- Fixes rust-embedded/book#249
- In the **Rust Embedded Discovery** book, it is noted to use `gdb` instead of `arm-none-eabi-gdb` as pointed out in rust-embedded/discovery#364 that `gdb` on Fedora justworks(tm). This was fixed for _Discovery_ book via rust-embedded/discovery#376
- Likewise, as mentioned per my comment in rust-embedded/book#249, on Fedora 37, `gdb` justworks(tm) as well.