### PR TITLE
remove extern crate statements

### DIFF
--- a/src/collections/index.md
+++ b/src/collections/index.md
@@ -49,9 +49,8 @@ in your program instead of this allocator.
 ``` rust,ignore
 // Bump pointer allocator implementation
 
-extern crate cortex_m;
-
-use core::alloc::GlobalAlloc;
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
 use core::ptr;
 
 use cortex_m::interrupt;
@@ -144,8 +143,7 @@ as they are exact same implementation.
 allocator. Just `use` its collections and proceed to instantiate them:
 
 ```rust,ignore
-extern crate heapless; // v0.4.x
-
+// heapless version: v0.4.x
 use heapless::Vec;
 use heapless::consts::*;
 
@@ -155,6 +153,7 @@ fn main() -> ! {
 
     xs.push(42).unwrap();
     assert_eq!(xs.pop(), Some(42));
+    loop {}
 }
 ```
 

--- a/src/interoperability/c-with-rust.md
+++ b/src/interoperability/c-with-rust.md
@@ -125,8 +125,6 @@ For projects with limited dependencies or complexity, or for projects where it i
 In the simplest case of compiling a single C file as a dependency to a static library, an example `build.rs` script using the [`cc` crate] would look like this:
 
 ```rust,ignore
-extern crate cc;
-
 fn main() {
     cc::Build::new()
         .file("foo.c")

--- a/src/peripherals/singletons.md
+++ b/src/peripherals/singletons.md
@@ -61,8 +61,7 @@ This has a small runtime overhead because we must wrap the `SerialPort` structur
 Although we created our own `Peripherals` structure above, it is not necessary to do this for your code. the `cortex_m` crate contains a macro called `singleton!()` that will perform this action for you.
 
 ```rust,ignore
-#[macro_use(singleton)]
-extern crate cortex_m;
+use cortex_m::singleton;
 
 fn main() {
     // OK if `main` is executed only once


### PR DESCRIPTION
from issue #41 

I kept this one because `alloc` can only be imported that way:

https://github.com/rust-embedded/book/blob/19f798d448835a4888e3b3eae7fe69f1d61d8681/src/collections/index.md?plain=1#L33

Closes #41 