### PR TITLE
add constgebra to list of math crates

### DIFF
--- a/src/unsorted/math.md
+++ b/src/unsorted/math.md
@@ -70,6 +70,7 @@ If you need to perform more complex operations like DSP signal processing or adv
 algebra on your MCU, the following crates might help you
 
 - [CMSIS DSP library binding](https://github.com/jacobrosenthal/cmsis-dsp-sys)
+- [`constgebra`](https://crates.io/crates/constgebra)
 - [`micromath`](https://github.com/tarcieri/micromath)
 - [`microfft`](https://crates.io/crates/microfft)
 - [`nalgebra`](https://github.com/dimforge/nalgebra)


### PR DESCRIPTION
`constgebra` is a crate for performing reproducible linear algebra in `const`/`no_std` contexts. Made it for a game, but seems like it might be helpful for embedded also. 