### PR TITLE
Mention generics in "optimizing dependencies"

### DIFF
--- a/src/unsorted/speed-vs-size.md
+++ b/src/unsorted/speed-vs-size.md
@@ -42,6 +42,12 @@ override the optimization level of dependencies. You can use that feature to
 optimize all dependencies for size while keeping the top crate unoptimized and
 debugger friendly.
 
+Beware that generic code can sometimes be optimized alongside the crate where it
+is instantiated, rather than the crate where it is defined. If you create an
+instance of a generic struct in your application and find that it pulls in code
+with a large footprint, it may be that increasing the optimisation level of the
+relevant dependencies has no effect.
+
 [`profile-overrides`]: https://doc.rust-lang.org/cargo/reference/profiles.html#overrides
 
 Here's an example:


### PR DESCRIPTION
I had some friction working with this part of the documentation - I was optimising my dependencies but still getting horrific flash usage.

It turns out to be because the profile override [has subtle interactions with generic code](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides-and-generics).

This PR adds a mention of that footgun.