### PR TITLE
Dependencies: changed "qemu-arch-extra" to "qemu-system-arm" on arch section

### DIFF
--- a/src/intro/install/linux.md
+++ b/src/intro/install/linux.md
@@ -54,7 +54,7 @@ sudo dnf install gdb openocd qemu-system-arm
 > Cortex-M programs
 
 ``` console
-sudo pacman -S arm-none-eabi-gdb qemu-arch-extra openocd
+sudo pacman -S arm-none-eabi-gdb qemu-system-arm openocd
 ```
 
 ## udev rules


### PR DESCRIPTION
qemu-arch-extra no longer exists in aur, all packages needed are moved to qemu-system-arm like the other distros