### PR TITLE
Use aligned address to demonstrate HardFault

### DIFF
--- a/src/start/exceptions.md
+++ b/src/start/exceptions.md
@@ -213,7 +213,7 @@ use cortex_m_semihosting::hio;
 fn main() -> ! {
     // read a nonexistent memory location
     unsafe {
-        ptr::read_volatile(0x3FFF_FFFE as *const u32);
+        ptr::read_volatile(0x3FFF_0000 as *const u32);
     }
 
     loop {}
@@ -236,14 +236,14 @@ you'll see something like this on the OpenOCD console.
 $ openocd
 (..)
 ExceptionFrame {
-    r0: 0x3ffffffe,
-    r1: 0x00f00000,
-    r2: 0x20000000,
+    r0: 0x3fff0000,
+    r1: 0x00000003,
+    r2: 0x080032e8,
     r3: 0x00000000,
     r12: 0x00000000,
-    lr: 0x080008f7,
-    pc: 0x0800094a,
-    xpsr: 0x61000000
+    lr: 0x080016df,
+    pc: 0x080016e2,
+    xpsr: 0x61000000,
 }
 ```
 


### PR DESCRIPTION
A volatile read from an unaligned pointer results in this when running in debug mode:
```
panicked at core/src/panicking.rs:221:5:
unsafe precondition(s) violated: ptr::read_volatile requires that the pointer argument is aligned and non-null
```
I changed the address to be aligned (but still invalid on F3 Discovery), so that the expected output is produced.

P.S. I was confused about the lack of output. Maybe default to `panic-semihosting`/`panic-itm` instead of `panic-halt` in these examples?