### PR TITLE
Update macOS installation instructions

### DIFF
--- a/src/intro/install/macos.md
+++ b/src/intro/install/macos.md
@@ -9,7 +9,7 @@ All the tools can be installed using [Homebrew] or [MacPorts]:
 
 ``` text
 $ # GDB
-$ brew install armmbed/formulae/arm-none-eabi-gcc
+$ brew install arm-none-eabi-gdb
 
 $ # OpenOCD
 $ brew install openocd


### PR DESCRIPTION
Follow-up to #119, which addressed #118

Timeline:

Date | Description | Related PR
--- | --- | ---
Jan 9, 2019 | `gcc-arm-embedded` was removed from `homebrew/cask` | https://github.com/Homebrew/homebrew-cask/pull/56802
Jan 26, 2019 | Rust Embedded Book was updated to use `armmbed/formulae/arm-none-eabi-gcc` | https://github.com/rust-embedded/book/pull/119
Dec 27, 2019 | `gcc-arm-none-eabi` formula was proposed in `homebrew/core` but rejected | https://github.com/Homebrew/homebrew-core/pull/45780
Jan 4, 2020 | `gcc-arm-embedded` was re-added to `homebrew/cask` | https://github.com/Homebrew/homebrew-cask/pull/75091
Aug 4, 2023 | `arm-none-eabi-gdb` formula was accepted into `homebrew/core` | https://github.com/Homebrew/homebrew-core/pull/138370
Aug 28, 2023 | `armmbed/formulae/arm-none-eabi-gcc` was deprecated | https://github.com/ARMmbed/homebrew-formulae/pull/39