### PR TITLE
Use dtolnay/rust-toolchain instead of actions-rs/toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
This fixes some warning emitted by github actions:
```
[warning]The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Also, actions-rs/toolchain looks deprecated, the repo at https://github.com/actions-rs/toolchain is archived.