### PR TITLE
Update outdated qemu documentation

### DIFF
--- a/src/start/qemu.md
+++ b/src/start/qemu.md
@@ -359,6 +359,9 @@ and RTT to print text.
 
 [defmt]: https://defmt.ferrous-systems.com/
 
+> **NOTE** `defmt` is a third-party dependency (i.e. non-core) widely used in the
+> Embedded Rust ecosystem.
+
 In order to read and decode the messages produced by `defmt` in the host, we need to
 switch the RTT transport output to semihosting. When using real hardware this requires
 a debug session but when using QEMU this Just Works.


### PR DESCRIPTION
I've seen #400 PR but I went ahead and modified the docs to use the new suggested template (https://github.com/knurling-rs/app-template).

The tricky part is that the new template uses `defmt`, so the `qemu-system-arm` binary is not enough but Ferrous System's [`qemu-run`](https://github.com/knurling-rs/defmt/tree/main/qemu-run/) tool is required to decode the output properly.

I'm not a big fan of third-party dependencies in the official docs, but feedback is welcome.
