### PR TITLE
Add a link to Rust for Zephyr

### DIFF
--- a/src/interoperability/index.md
+++ b/src/interoperability/index.md
@@ -58,6 +58,10 @@ We are collecting examples and use cases for this on our issue tracker in
 Integrating Rust with an RTOS such as FreeRTOS or ChibiOS is still a work in
 progress; especially calling RTOS functions from Rust can be tricky.
 
+Currently, the following projects publicly support Rust<->RTOS interoperability:
+
+* [Zephyr Project](https://docs.zephyrproject.org/latest/develop/languages/rust/index.html)
+
 We are collecting examples and use cases for this on our issue tracker in
 [issue #62].
 


### PR DESCRIPTION
Add the link of `Rust For Zephyr` in the `##Interoperability with RTOSs` section of the `interoperability` chapter.